### PR TITLE
Add modular chatbot skeleton

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "backend.api.server:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -1,17 +1,47 @@
-# SMEAI
+# SMEAI Chatbot Skeleton
 
-## Overview
-SMEAI is a Python project that demonstrates basic functionality with a simple `main.py` script.
+This repository contains a starter layout for an authenticated retrieval augmented
+chatbot powered by a local Mixtral LLM. The code is organised in modular
+components under the `backend/` directory.
 
-## Files
-- `main.py`: Contains the main function that prints "Hello, World!" to the console.
+## Directory Structure
 
-## How to Run
-1. Ensure you have Python installed on your system.
-2. Run the following command in the terminal:
+```
+backend/
+    ingest/            # Build FAISS index from raw documents
+    retrieval/         # Query handling and vector search
+    llm/               # Mixtral client wrapper
+    api/               # FastAPI application
+    auth/              # Token to user mapping
+    config.py          # Shared configuration values
+
+data/                 # Persisted FAISS index and metadata
+Dockerfile            # Container setup
+requirements.txt      # Python dependencies
+.env                  # Environment variables
+```
+
+## Running Locally
+
+1. Install dependencies:
    ```bash
-   python main.py
+   pip install -r requirements.txt
+   ```
+2. Build the document index (placeholder command):
+   ```bash
+   python backend/ingest/build_index.py
+   ```
+3. Start the API server:
+   ```bash
+   uvicorn backend.api.server:app --reload
+   ```
+4. Send a request:
+   ```bash
+   curl -X POST "http://localhost:8000/query" -d 'token=abc123token&query=hello'
    ```
 
-## License
-This project is licensed under the MIT License.
+## Status
+
+This project provides only pseudocode placeholders for the ingestion pipeline,
+vector search, and LLM interaction. It is intended as a starting point for a
+full-scale application.

--- a/backend/api/server.py
+++ b/backend/api/server.py
@@ -1,0 +1,22 @@
+"""FastAPI server exposing chatbot endpoints."""
+
+from fastapi import FastAPI, HTTPException
+
+from ..retrieval.query_bot import answer_query
+
+app = FastAPI()
+
+
+@app.get("/health")
+def health_check():
+    return {"status": "ok"}
+
+
+@app.post("/query")
+def query_endpoint(token: str, query: str):
+    """Return the LLM answer for a user's query."""
+    try:
+        answer = answer_query(query, token)
+    except Exception as exc:  # pragma: no cover - placeholder error handling
+        raise HTTPException(status_code=500, detail=str(exc))
+    return {"answer": answer}

--- a/backend/auth/tokens.py
+++ b/backend/auth/tokens.py
@@ -1,0 +1,8 @@
+"""Static token to user mapping."""
+
+# In production this would be replaced by a persistent store or JWT auth
+
+TOKEN_TO_USER = {
+    "abc123token": "hirsh",
+    "xyz456token": "john",
+}

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,11 @@
+"""Configuration settings for the chatbot application."""
+
+from pathlib import Path
+
+# Paths for persisted data
+DATA_DIR = Path("data")
+FAISS_INDEX_PATH = DATA_DIR / "faiss_index.index"
+METADATA_PATH = DATA_DIR / "metadata.json"
+
+# Authentication tokens will be loaded from .env or tokens.py
+# Add additional configuration values as needed

--- a/backend/ingest/build_index.py
+++ b/backend/ingest/build_index.py
@@ -1,0 +1,19 @@
+"""Pipeline for building the FAISS index and metadata store."""
+
+# Pseudocode outline for build_index
+# 1. Load raw documents from external sources or local files.
+# 2. Split documents into chunks using functions from ``chunking_utils``.
+# 3. Embed chunks using a sentence transformer model.
+# 4. Store embeddings in a FAISS index and write metadata mapping IDs to text
+#    and authorized user IDs.
+#
+# Actual implementation would require dependencies like ``sentence-transformers``
+# and ``faiss``. Those are not included in this skeleton.
+
+def main():
+    """Entry point to build the index."""
+    pass  # TODO: implement ingestion logic
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/ingest/chunking_utils.py
+++ b/backend/ingest/chunking_utils.py
@@ -1,0 +1,8 @@
+"""Utility functions for text chunking and cleaning."""
+
+# Pseudocode only - implement tokenization and cleaning logic here.
+
+def split_into_chunks(text: str, max_tokens: int = 500):
+    """Return a list of text chunks each under ``max_tokens``."""
+    # TODO: add real tokenization logic
+    return [text]

--- a/backend/llm/mixtral_client.py
+++ b/backend/llm/mixtral_client.py
@@ -1,0 +1,9 @@
+"""Client for interacting with a local Mixtral model."""
+
+# This is a placeholder for whichever LLM backend you use.
+# Replace with actual calls to vLLM, Ollama, etc.
+
+def ask_mixtral(query: str, context_chunks) -> str:
+    """Return an answer string from the Mixtral model."""
+    # TODO: implement real model inference
+    return "Mixtral response placeholder"

--- a/backend/retrieval/access_control.py
+++ b/backend/retrieval/access_control.py
@@ -1,0 +1,12 @@
+"""Simple token-based access control for retrieved chunks."""
+
+from ..auth.tokens import TOKEN_TO_USER
+
+
+def filter_chunks(chunks, token: str):
+    """Return only chunks a user is allowed to see."""
+    user = TOKEN_TO_USER.get(token)
+    if user is None:
+        return []
+    # Each chunk should contain metadata with allowed users
+    return [c for c in chunks if user in c.get("user_ids", [])]

--- a/backend/retrieval/query_bot.py
+++ b/backend/retrieval/query_bot.py
@@ -1,0 +1,18 @@
+"""High-level query handling for the chatbot."""
+
+# The query_bot orchestrates embedding the query, retrieving documents, filtering
+# by user permissions, and calling the language model.
+
+from .vector_search import embed_and_search
+from .access_control import filter_chunks
+from ..llm.mixtral_client import ask_mixtral
+
+
+def answer_query(query: str, token: str) -> str:
+    """Return an answer to ``query`` for the user associated with ``token``."""
+    # 1. Embed query and retrieve candidate chunks
+    chunks = embed_and_search(query)
+    # 2. Filter chunks based on access control
+    allowed_chunks = filter_chunks(chunks, token)
+    # 3. Assemble context and send to LLM
+    return ask_mixtral(query, allowed_chunks)

--- a/backend/retrieval/vector_search.py
+++ b/backend/retrieval/vector_search.py
@@ -1,0 +1,8 @@
+"""Utilities for embedding queries and performing vector search."""
+
+# Pseudocode only - uses FAISS in a real implementation
+
+def embed_and_search(query: str, top_k: int = 5):
+    """Return a list of top matching chunks for ``query``."""
+    # TODO: embed the query and perform FAISS search
+    return []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+faiss-cpu
+sentence-transformers


### PR DESCRIPTION
## Summary
- bootstrap directories for ingest, retrieval, llm, auth and api
- provide pseudocode for building index, vector search and mixtral client
- implement FastAPI server stub with /query and /health endpoints
- add Dockerfile, requirements and config module
- document repo usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d88267cf883219a0e108803a68f6e