### PR TITLE
Switch ingestion to Jira REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ User-interface code is placed under the new `frontend/` directory.
 
 ```
 backend/
-    ingest/            # Build FAISS index from raw documents
+    ingest/            # Build FAISS index from Jira pages
+        jira_client.py    # Fetch pages via Jira REST API
     retrieval/         # Query handling and vector search
     llm/               # Mixtral client wrapper
     api/               # FastAPI application
@@ -39,11 +40,18 @@ requirements.txt      # Python dependencies
    pip install -r requirements.txt
    ```
 
+### Jira integration
+
+Set the Jira base URL and credentials in `backend/config.py` before running the
+ingestion pipeline. The example placeholders show where to configure
+`JIRA_BASE_URL`, `JIRA_EMAIL` and `JIRA_API_TOKEN`.
+
 ## Running Locally
 
-1. Build the document index (placeholder command):
+1. Build the document index from Jira pages:
    ```bash
    python backend/ingest/build_index.py
+   # The script fetches pages using Jira's REST API and indexes them
    ```
 2. Start the API server:
    ```bash
@@ -57,5 +65,5 @@ requirements.txt      # Python dependencies
 ## Status
 
 This project provides only pseudocode placeholders for the ingestion pipeline,
-vector search, and LLM interaction. It is intended as a starting point for a
+vector search, Jira REST API integration, and LLM interaction. It is intended as a starting point for a
 full-scale application.

--- a/backend/config.py
+++ b/backend/config.py
@@ -7,5 +7,10 @@ DATA_DIR = Path("data")
 FAISS_INDEX_PATH = DATA_DIR / "faiss_index.index"
 METADATA_PATH = DATA_DIR / "metadata.json"
 
+# Jira REST API settings
+JIRA_BASE_URL = "https://your-domain.atlassian.net"
+JIRA_EMAIL = "user@example.com"
+JIRA_API_TOKEN = "your_token_here"
+
 # Authentication tokens will be loaded from .env or tokens.py
 # Add additional configuration values as needed

--- a/backend/ingest/build_index.py
+++ b/backend/ingest/build_index.py
@@ -1,7 +1,7 @@
 """Pipeline for building the FAISS index and metadata store."""
 
 # Pseudocode outline for build_index
-# 1. Load raw documents from external sources or local files.
+# 1. Load raw documents from Jira pages using the REST API.
 # 2. Split documents into chunks using functions from ``chunking_utils``.
 # 3. Embed chunks using a sentence transformer model.
 # 4. Store embeddings in a FAISS index and write metadata mapping IDs to text
@@ -10,9 +10,18 @@
 # Actual implementation would require dependencies like ``sentence-transformers``
 # and ``faiss``. Those are not included in this skeleton.
 
+from .jira_client import fetch_jira_pages
+from .chunking_utils import split_into_chunks
+
+
 def main():
     """Entry point to build the index."""
-    pass  # TODO: implement ingestion logic
+    # Example pseudocode using the Jira client
+    pages = fetch_jira_pages("project = SME")
+    for page in pages:
+        chunks = split_into_chunks(page)
+        # TODO: embed chunks and build the FAISS index
+        pass
 
 
 if __name__ == "__main__":

--- a/backend/ingest/jira_client.py
+++ b/backend/ingest/jira_client.py
@@ -1,0 +1,11 @@
+"""Helpers for retrieving pages from Jira via its REST API."""
+
+# This module contains only placeholder code. In a real implementation you would
+# use the ``jira`` library or ``requests`` to authenticate and download page
+# content from your Jira instance.
+
+
+def fetch_jira_pages(jql: str):
+    """Return a list of page contents matching the JQL query ``jql``."""
+    # TODO: perform REST API calls to Jira and assemble page text
+    return []

--- a/environment.yml
+++ b/environment.yml
@@ -26,3 +26,5 @@ dependencies:
       - uvicorn
       - faiss-cpu
       - sentence-transformers
+      - jira
+      - requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 faiss-cpu
 sentence-transformers
+jira
+requests


### PR DESCRIPTION
## Summary
- fetch documents from Jira pages
- add Jira REST API placeholders in config and ingestion pseudocode
- document Jira integration and update dependencies

## Testing
- `python -m py_compile backend/ingest/build_index.py backend/ingest/jira_client.py backend/config.py`

------
https://chatgpt.com/codex/tasks/task_e_685d8eb9a0248321bd37b3dc13024be5